### PR TITLE
Fix bug in parseFloats that corrupted data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ const parseFloats = rows => {
 
   for (const row of rows) {
     for (let i = 0; i < row.length; i++) {
-      if (Number.isNaN(parseFloat(row[i]))) {
+      if (row[i] !== parseFloat(row[i]).toString()) {
         allFloats.delete(i);
       }
 

--- a/src/App.js
+++ b/src/App.js
@@ -150,7 +150,7 @@ class App extends Component {
           </div>
         </nav>
 
-        <div className="container above-footer full-width">
+        <div className="container-fluid above-footer full-width">
           <QueryForm status={this.state.status} />
           {this.state.status === "init" ? (
             <p

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -132,7 +132,8 @@ class Grid extends Component {
             key: col,
             name: col,
             filterable: true,
-            sortable: true
+            sortable: true,
+            resizable: true
           };
         })}
         minHeight={window.innerHeight - 200}

--- a/test.csv
+++ b/test.csv
@@ -1,3 +1,3 @@
-a',-b
-1,2
-3,4
+number',-quotedstring,ip
+1,"12"" vinyl",192.168.0.123
+3,"42 is answer",10.42.42.42


### PR DESCRIPTION
parseFloat returns a number if the string starts with a number. This caused columns full of IP addresses to be corrupted, i.e. "1.2.3.4" became 1.2.

Fix is to check is round-trip from string-to-float then float-to-string matches the original value.

Also changed test.csv to test this (and test quoted strings)

Also, use full width of page and make columns user resizable to help with analysis of wide csv files.