### PR TITLE
feat: Add 'Export Query Result' button which downloads csv file of query result set

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import Papa from "papaparse";
 import React, { Component } from "react";
 import Button from "react-bootstrap/lib/Button";
 import Modal from "react-bootstrap/lib/Modal";
@@ -111,16 +112,33 @@ class App extends Component {
     }
   };
 
+  downloadResultSet = () => {
+    var outputData = this.state.result.rows;
+    outputData.unshift(this.state.result.cols);
+    const csvString = Papa.unparse(outputData);
+    const blob = new Blob([csvString], { type: "text/csv;charset=utf-8;" });
+
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", "CSV SQL LIVE output.csv");
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
   updateState = state => {
     this.setState(state);
   };
 
   componentDidMount() {
+    emitter.addListener("downloadResultSet", this.downloadResultSet);
     emitter.addListener("runQuery", this.runQuery);
     emitter.addListener("updateState", this.updateState);
   }
 
   componentWillUnmount() {
+    emitter.removeListener("downloadResultSet", this.downloadResultSet);
     emitter.removeListener("runQuery", this.runQuery);
     emitter.removeListener("updateState", this.updateState);
   }

--- a/src/QueryForm.js
+++ b/src/QueryForm.js
@@ -8,7 +8,10 @@ import emitter from "./emitter";
 class QueryForm extends Component {
   constructor(props) {
     super(props);
-    this.state = { queryText: "" };
+    this.state = {
+      queryText: "",
+      queryRan: false
+    };
   }
 
   handleChange = e => {
@@ -18,6 +21,14 @@ class QueryForm extends Component {
   handleSubmit = e => {
     e.preventDefault();
     emitter.emit("runQuery", this.state.queryText);
+    this.setState({
+      queryRan: true
+    });
+  };
+
+  handleClick = e => {
+    e.preventDefault();
+    emitter.emit("downloadResultSet");
   };
 
   newTable = tableName => {
@@ -54,8 +65,20 @@ class QueryForm extends Component {
             }
           />
           <Button
-            bsStyle="primary"
+            onClick={this.handleClick}
+            bsStyle="success"
             style={{ marginTop: "0.5em" }}
+            className="pull-right"
+            disabled={
+              this.props.status !== "loaded" ||
+              this.state.queryRan === false
+            }
+          >
+            Export Query Result
+          </Button>
+          <Button
+            bsStyle="primary"
+            style={{ marginTop: "0.5em", marginRight: "0.5em" }}
             className="pull-right"
             type="submit"
             disabled={


### PR DESCRIPTION
I've used this tool a bit and I am finding it useful.
As pointed out here #2, it would be nice if you could download the result of a query, so that is what this pull request is for.

I am new to node.js, so maybe some of this could be done better, not sure. It seems to work well though.

Would be cool if this got merged.